### PR TITLE
Fix division by zero error in average_ratios function

### DIFF
--- a/failing_calculator.py
+++ b/failing_calculator.py
@@ -1,7 +1,11 @@
 def average_ratios(numbers):
+    if not numbers:
+        raise ValueError("List cannot be empty")
     total = 0
-    for i in range(len(numbers)):
-        total += 100 / numbers[i]
+    for num in numbers:
+        if num == 0:
+            raise ValueError("Division by zero: cannot divide by zero")
+        total += 100 / num
     return total / len(numbers)
 
 print(average_ratios([10, 5, 0]))


### PR DESCRIPTION
- Add check for zero values and raise ValueError with descriptive message
- Add check for empty list to prevent division by zero in average calculation

## Summary by Sourcery

Prevent average_ratios from crashing on empty input or zero values by validating the input before computing ratios.

Bug Fixes:
- Raise a ValueError for empty input lists to avoid division by zero in the average calculation.
- Raise a ValueError when encountering zero elements to prevent division by zero in the ratio computation.